### PR TITLE
traefik log dir cannot be read-only

### DIFF
--- a/services/docker-compose.crowdsec.yaml
+++ b/services/docker-compose.crowdsec.yaml
@@ -13,8 +13,8 @@ services:
       - ./crowdsec/acquis.yaml:/etc/crowdsec/acquis.yaml:ro
       - ./crowdsec/data:/var/lib/crowdsec/data/
       - ./crowdsec/etc:/etc/crowdsec/
-      - /var/log/:/var/log:ro
-      - ./traefik/logs:/var/log/traefik:ro
+      - /var/log/:/var/log
+      - ./traefik/logs:/var/log/traefik
     labels:
       - traefik.enable=false
     networks:


### PR DESCRIPTION
On my system crowdsec container does not start complaining to try to mount /var/log/traefik on a read only /var/log dir