### PR TITLE
prometheus data dir fixed

### DIFF
--- a/services/docker-compose.grafana.yaml.j2
+++ b/services/docker-compose.grafana.yaml.j2
@@ -92,7 +92,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     container_name: prometheus
-    user: "1000:1000"
+    user: "1000:100"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus/data:/prometheus

--- a/services/docker-compose.portainer.yaml.j2
+++ b/services/docker-compose.portainer.yaml.j2
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   portainer:
-    image: portainer/portainer-ce
+    image: portainer/portainer-ce:2.21.5
     env_file:
       - .env
     container_name: portainer

--- a/services/dockge/stacks/lab-tools-jupyter/compose.yaml.j2
+++ b/services/dockge/stacks/lab-tools-jupyter/compose.yaml.j2
@@ -8,7 +8,6 @@ services:
       "sh", 
       "-c",
       "apk add --no-cache git && \
-      git clone https://github.com/NirDiamant/GenAI_Agents.git /home/{{ lab_user }}/workspace/courses/genai-agents && \
       git clone https://github.com/anthropics/courses.git /home/{{ lab_user }}/workspace/courses/anthropics && \
       git clone https://github.com/huggingface/smolagents.git /home/{{ lab_user }}/workspace/courses/smolagents && \
       git clone https://github.com/pjirsa/langchain-quickstart /home/{{ lab_user }}/workspace/courses/langchain && \

--- a/services/loki/local-config.yaml
+++ b/services/loki/local-config.yaml
@@ -49,6 +49,10 @@ frontend:
 query_range:
   parallelise_shardable_queries: true
 
+# The setting below is required, since we are using v11 schema above!
+# allow_structured_metadata: false
+
 limits_config:
   split_queries_by_interval: 15m
   max_query_parallelism: 32
+  allow_structured_metadata: false

--- a/services/traefik/conf.d/code-server.yml
+++ b/services/traefik/conf.d/code-server.yml
@@ -3,7 +3,6 @@ http:
     sablier-dynamic-code-server:
       plugin:
         sablier:
-          group: default
           names: lab-code-server
           dynamic:
             displayName: Code Server

--- a/services/traefik/conf.d/whoami.yml
+++ b/services/traefik/conf.d/whoami.yml
@@ -3,7 +3,6 @@ http:
     sablier-dynamic-whoami:
       plugin:
         sablier:
-          group: default
           names: whoami
           dynamic:
             displayName: Whoami


### PR DESCRIPTION
The previous fix for prometheus was wrong.
In the current fix the process will run as 1000:100. (So this is reverted in the composer file)
However the data directory for prometheus does not exist at the start of the prometheus container, so docker will create it.
In this case the permissions for the data directory will be root:root. This caused the problem, since user 1000
wants to write into a directory owned by root. Theoretically the ansible script would take care of this -
by setting the permission of everything under prometheus to 1000:100, but as I said the data directory
does not exist before starting the container, at the time of the execution of ansible.
In this fix, the data directory is added, so ansible will set the correct permissions and prometheus will run correctly as well.

In loki v11 schema is used. The container required the added line. Without that it does not start.

jupyter-content contains duplicate cloning. Due to this the execution stops, therefore chown does not execute properly, so there will be no permission for the user.